### PR TITLE
Draft TopicRecordNameStrategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ examples/avro/go.mod
 examples/avro/go.sum
 examples/avro/Makefile
 
+/.idea
+

--- a/serde/avro/avro_specific.go
+++ b/serde/avro/avro_specific.go
@@ -151,6 +151,7 @@ func (s *SpecificSerializer) addFullyQualifiedNameToSchema(avroStr string, msg i
 
 // SerializeRecordName implements serialization of generic Avro data
 func (s *SpecificSerializer) SerializeRecordName(msg interface{}, subject ...string) ([]byte, error) {
+	s.SubjectNameStrategy = serde.TopicNameStrategy
 	if msg == nil {
 		return nil, nil
 	}
@@ -198,6 +199,7 @@ func (s *SpecificSerializer) SerializeRecordName(msg interface{}, subject ...str
 
 // SerializeTopicRecordName implements serialization of generic Avro data
 func (s *SpecificSerializer) SerializeTopicRecordName(topic string, msg interface{}, subject ...string) ([]byte, error) {
+	s.SubjectNameStrategy = serde.TopicRecordNameStrategy
 	if msg == nil {
 		return nil, nil
 	}
@@ -258,6 +260,7 @@ func NewSpecificDeserializer(client schemaregistry.Client, serdeType serde.Type,
 
 // DeserializeTopicRecordName implements deserialization of specific Avro data
 func (s *SpecificDeserializer) DeserializeTopicRecordName(topic string, payload []byte) (interface{}, error) {
+	s.SubjectNameStrategy = serde.TopicRecordNameStrategy
 	if payload == nil {
 		return nil, nil
 	}
@@ -461,6 +464,7 @@ func (s *SpecificDeserializer) DeserializeRecordName(payload []byte) (interface{
 
 // DeserializeIntoTopicRecordName implements deserialization of specific Avro data
 func (s *SpecificDeserializer) DeserializeIntoTopicRecordName(topic string, subjects map[string]interface{}, payload []byte) error {
+	s.SubjectNameStrategy = serde.TopicRecordNameStrategy
 	if payload == nil {
 		return nil
 	}

--- a/serde/avro/avro_specific_test.go
+++ b/serde/avro/avro_specific_test.go
@@ -532,7 +532,11 @@ func RegisterTRNMessageFactorySpecificOnSubject() func([]string, string) (interf
 			switch s {
 			case topicExampleNamespaceValue, secondExampleNamespaceValue:
 				return &rn.DemoSchema{}, nil
+			case topicExampleNamespace, secondExampleNamespace:
+				return &rn.DemoSchema{}, nil
 			case topicComplexDTNamespaceValue, secondComplexDTNamespaceValue:
+				return &rn.Advanced{}, nil
+			case topicComplexDTNamespace, secondComplexDTNamespace:
 				return &rn.Advanced{}, nil
 			}
 		}
@@ -591,7 +595,7 @@ func TestAvroSpecificSerdeDeserializeTopicRecordNameWithoutHandler(t *testing.T)
 
 	// object without packagename
 	newobj, err = deser.DeserializeTopicRecordName("invalid", bytesInner2)
-	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-recordname.DemoSchema-value"))
+	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-recordname.DemoSchema"))
 	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(newobj, nil))
 
 	newobj, err = deser.DeserializeTopicRecordName(topic, bytesObj)
@@ -599,7 +603,7 @@ func TestAvroSpecificSerdeDeserializeTopicRecordNameWithoutHandler(t *testing.T)
 
 	// object with packagename
 	newobj, err = deser.DeserializeTopicRecordName("invalid", bytesObj)
-	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-python.test.advanced.advanced-value"))
+	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-python.test.advanced.advanced"))
 	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(newobj, nil))
 
 }
@@ -641,7 +645,7 @@ func TestAvroSpecificSerdeDeserializeTopicRecordNameWithHandlerAndPackageName(t 
 	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(*rn.Advanced).Friends["second"].Number.Long, complexDT.Friends["second"].Number.Long))
 
 	newobj, err = deser.DeserializeTopicRecordName("invalid", bytesObj2)
-	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-python.test.advanced.advanced-value"))
+	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-python.test.advanced.advanced"))
 	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(newobj, nil))
 }
 
@@ -682,7 +686,7 @@ func TestAvroSpecificSerdeDeserializeTopicRecordNameWithHandlerAndPackageNameOnS
 	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(*rn.Advanced).Friends["second"].Number.Long, complexDT.Friends["second"].Number.Long))
 
 	newobj, err = deser.DeserializeTopicRecordName("invalid", bytesObj2)
-	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-python.test.advanced.advanced-value"))
+	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-python.test.advanced.advanced"))
 	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(newobj, nil))
 }
 
@@ -718,7 +722,7 @@ func TestAvroSpecificSerdeDeserializeTopicRecordNameWithHandlerAndNoPackageName(
 	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(*rn.DemoSchema).StringField, example.StringField))
 
 	newobj, err = deser.DeserializeTopicRecordName("invalid", bytesInner2)
-	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-recordname.DemoSchema-value"))
+	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-recordname.DemoSchema"))
 	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(newobj, nil))
 }
 
@@ -754,7 +758,7 @@ func TestAvroSpecificSerdeDeserializeTopicRecordNameWithHandlerAndNoPackageNameO
 	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(*rn.DemoSchema).StringField, example.StringField))
 
 	newobj, err = deser.DeserializeTopicRecordName("invalid", bytesInner2)
-	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-recordname.DemoSchema-value"))
+	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(err.Error(), "no subject found for: invalid-recordname.DemoSchema"))
 	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(newobj, nil))
 }
 
@@ -846,9 +850,9 @@ func TestAvroSpecificSerdeDeserializeIntoTopicRecordName(t *testing.T) {
 	serde.MaybeFail("serialization", err)
 
 	var receivers = make(map[string]interface{})
-	receivers[topicExampleNamespaceValue] = &rn.DemoSchema{}
-	receivers[secondExampleNamespaceValue] = &rn.DemoSchema{}
-	receivers[topicComplexDTNamespaceValue] = &rn.Advanced{}
+	receivers[topicExampleNamespace] = &rn.DemoSchema{}
+	receivers[secondExampleNamespace] = &rn.DemoSchema{}
+	receivers[topicComplexDTNamespace] = &rn.Advanced{}
 
 	deser, err := NewSpecificDeserializer(client, serde.ValueSerde, NewDeserializerConfig())
 
@@ -856,16 +860,16 @@ func TestAvroSpecificSerdeDeserializeIntoTopicRecordName(t *testing.T) {
 	deser.Client = ser.Client
 
 	err = deser.DeserializeIntoTopicRecordName(topic, receivers, bytesInner)
-	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicExampleNamespaceValue].(*rn.DemoSchema).StringField, example.StringField))
+	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicExampleNamespace].(*rn.DemoSchema).StringField, example.StringField))
 
 	err = deser.DeserializeIntoTopicRecordName(second, receivers, bytesInner2)
-	serde.MaybeFail("deserialization", err, serde.Expect(receivers[secondExampleNamespaceValue].(*rn.DemoSchema).StringField, example.StringField))
+	serde.MaybeFail("deserialization", err, serde.Expect(receivers[secondExampleNamespace].(*rn.DemoSchema).StringField, example.StringField))
 
 	err = deser.DeserializeIntoTopicRecordName(topic, receivers, bytesObj)
-	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicComplexDTNamespaceValue].(*rn.Advanced).Number.Long, complexDT.Number.Long))
-	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicComplexDTNamespaceValue].(*rn.Advanced).Name.String, complexDT.Name.String))
-	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicComplexDTNamespaceValue].(*rn.Advanced).Friends["first"].Name.String, complexDT.Friends["first"].Name.String))
-	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicComplexDTNamespaceValue].(*rn.Advanced).Friends["second"].Number.Long, complexDT.Friends["second"].Number.Long))
+	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicComplexDTNamespace].(*rn.Advanced).Number.Long, complexDT.Number.Long))
+	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicComplexDTNamespace].(*rn.Advanced).Name.String, complexDT.Name.String))
+	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicComplexDTNamespace].(*rn.Advanced).Friends["first"].Name.String, complexDT.Friends["first"].Name.String))
+	serde.MaybeFail("deserialization", err, serde.Expect(receivers[topicComplexDTNamespace].(*rn.Advanced).Friends["second"].Number.Long, complexDT.Friends["second"].Number.Long))
 }
 
 func TestAvroSpecificSerdeDeserializeIntoTopicRecordNameWithInvalidSchema(t *testing.T) {
@@ -912,8 +916,8 @@ func TestAvroSpecificSerdeDeserializeIntoTopicRecordNameWithInvalidReceiver(t *t
 	serde.MaybeFail("serialization", err)
 
 	var receivers = make(map[string]interface{})
-	receivers[topicExampleNamespaceValue] = &rn.Advanced{}
-	receivers[topicComplexDTNamespaceValue] = ""
+	receivers[topicExampleNamespace] = &rn.Advanced{}
+	receivers[topicComplexDTNamespace] = ""
 
 	deser, err := NewSpecificDeserializer(client, serde.ValueSerde, NewDeserializerConfig())
 
@@ -923,11 +927,11 @@ func TestAvroSpecificSerdeDeserializeIntoTopicRecordNameWithInvalidReceiver(t *t
 	err = deser.DeserializeIntoTopicRecordName(topic, receivers, bytesInner)
 	parts := strings.Split(err.Error(), ":")
 	serde.MaybeFail("deserializeInvalidReceiver", serde.Expect(parts[0], "Incompatible types by name"))
-	serde.MaybeFail("deserialization", serde.Expect(fmt.Sprintf("%v", receivers[topicExampleNamespaceValue]), `&{<nil> { 0} map[] map[]}`))
+	serde.MaybeFail("deserialization", serde.Expect(fmt.Sprintf("%v", receivers[topicExampleNamespace]), `&{<nil> { 0} map[] map[]}`))
 
 	err = deser.DeserializeIntoTopicRecordName(topic, receivers, bytesObj)
 	serde.MaybeFail("deserialization", serde.Expect(err.Error(), "deserialization target must be an avro message. Got ''"))
-	serde.MaybeFail("deserialization", serde.Expect(receivers[topicComplexDTNamespaceValue], ""))
+	serde.MaybeFail("deserialization", serde.Expect(receivers[topicComplexDTNamespace], ""))
 }
 
 func TestAvroSpecificSerdeTopicRecordNamePayloadMismatchSubject(t *testing.T) {

--- a/serde/serde.go
+++ b/serde/serde.go
@@ -150,8 +150,23 @@ func TopicNameStrategy(topic string, serdeType Type, fullyQualifiedName ...strin
 	return topic + suffix, nil
 }
 
+// TopicRecordNameStrategy creates a subject name by <topic>-<type>.
+// Where <topic> is the Kafka topic name, and
+// <type> is the fully-qualified name of the Avro record type of the message.
+func TopicRecordNameStrategy(topic string, _ Type, fullyQualifiedName ...string) (string, error) {
+	if topic != "" && len(fullyQualifiedName) > 0 && fullyQualifiedName[0] != "" {
+		return fmt.Sprintf("%s-%s", topic, fullyQualifiedName[0]), nil
+	}
+
+	if topic == "" && len(fullyQualifiedName) > 0 && fullyQualifiedName[0] != "" {
+		return fmt.Sprintf("%s", fullyQualifiedName[0]), nil
+	}
+
+	return topic, nil
+}
+
 // GetID returns a schema ID for the given schema
-func (s *BaseSerializer) GetID(subject string, msg interface{}, info schemaregistry.SchemaInfo) (int, int, error) {
+func (s *BaseSerializer) GetID(subject string, _ interface{}, info schemaregistry.SchemaInfo) (int, int, error) {
 	autoRegister := s.Conf.AutoRegisterSchemas
 	useSchemaID := s.Conf.UseSchemaID
 	useLatest := s.Conf.UseLatestVersion


### PR DESCRIPTION
Draft of supporting TopicRecordNameStrategy for resolving the schema subject. 

This PR is not ready to be merged, this is to open a discussion.

Comments:
- The SubjectResolver function maybe it should be initialize not in the Base(De)Serializer